### PR TITLE
Add support for Coveralls to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19", clang_version: 19, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
           - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
-          - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan;Gcov\" ", coverage: true}
           - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
     steps:
@@ -77,6 +77,11 @@ jobs:
           sudo apt-get install g++-${GCC_VERSION} gcc-${GCC_VERSION}
           find /usr/lib/x86_64-linux-gnu/ -name libstdc++.so*
           g++-${GCC_VERSION} --version
+      - name: Install Gcovr
+        if: matrix.config.coverage
+        run: |
+          set -x
+          sudo apt-get install gcovr
       - name: CMake Configure
         run: |
           set -x
@@ -107,3 +112,25 @@ jobs:
         run: |
           set -x
           cmake --install .build --config RelWithDebInfo --component beman_optional26_development --verbose
+      - name: CMake Gcov Build
+        if: matrix.config.coverage
+        run: |
+          set -x
+          cmake --build .build --config Gcov --target all_verify_interface_header_sets -- -k 0
+          cmake --build .build --config Gcov --target all -- -k 0
+      - name: CMake Gcov Test
+        if: matrix.config.coverage
+        run: |
+          set -x
+          ctest --build-config Gcov --output-on-failure --test-dir .build
+      - name: Generate Coverage
+        if: matrix.config.coverage
+        run: |
+          set -x
+          cmake --build .build --config Gcov --target process_coverage -- -k 0
+      - name: Coveralls
+        if: matrix.config.coverage
+        uses: coverallsapp/github-action@main
+        with:
+          file: ${{runner.workspace}}/optional26/.build/coverage.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 SPDX-License-Identifier: 2.0 license with LLVM exceptions
 -->
 
-![CI Tests](https://github.com/bemanproject/optional26/actions/workflows/ci.yml/badge.svg)
+![CI Tests](https://github.com/bemanproject/optional26/actions/workflows/ci.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/optional26/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/optional26?branch=main)
 
 This repository implements `std::optional` extensions targeting C++26. The `beman.optional26` library aims to evaluate
 the stability, the usability, and the performance of these proposed changes before they are officially adopted by WG21

--- a/cmake/gcovr.cfg.in
+++ b/cmake/gcovr.cfg.in
@@ -9,3 +9,5 @@ html-self-contained = yes
 print-summary = yes
 filter = .*/beman/optional26/.*
 exclude = .*\.t\.cpp
+coveralls = coverage.json
+coveralls-pretty = yes


### PR DESCRIPTION
This commit provides support for Coveralls CI by leveraging the existing Gcov build configuration, adding configuration so that gcovr generates coverage data in Coveralls JSON format, and adding steps to the CI build job that are activated only if the matrix entry is configured for coverage, which generate coverage data and deliver it to Coveralls.

It also adds a coverage badge to the README.