### PR TITLE
When moving a 'optional<T&>', don't move the remote value

### DIFF
--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -488,7 +488,7 @@ inline constexpr optional<T>::optional(optional<U>&& rhs)
     requires detail::enable_from_other<T, U, U&&> && std::is_convertible_v<U&&, T>
 {
     if (rhs.has_value()) {
-        construct(std::move(*rhs));
+        construct(*std::move(rhs));
     }
 }
 
@@ -498,7 +498,7 @@ inline constexpr optional<T>::optional(optional<U>&& rhs)
     requires detail::enable_from_other<T, U, U&&> && (!std::is_convertible_v<U &&, T>)
 {
     if (rhs.has_value()) {
-        construct(std::move(*rhs));
+        construct(*std::move(rhs));
     }
 }
 
@@ -594,14 +594,14 @@ inline constexpr optional<T>& optional<T>::operator=(optional<U>&& rhs)
 {
     if (has_value()) {
         if (rhs.has_value()) {
-            value_ = std::move(*rhs);
+            value_ = *std::move(rhs);
         } else {
             hard_reset();
         }
     }
 
     else if (rhs.has_value()) {
-        construct(std::move(*rhs));
+        construct(*std::move(rhs));
     }
 
     return *this;

--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -294,11 +294,11 @@ class optional {
 
     template <class U>
     constexpr explicit(!std::is_convertible_v<U&, T>) optional(const optional<U&>& rhs)
-        requires(detail::enable_from_other<T, U, U&> && std::is_convertible_v<U&, T>);
+        requires(detail::enable_from_other<T, U&, U&> && std::is_convertible_v<U&, T>);
 
     template <class U>
     constexpr explicit(!std::is_convertible_v<U&, T>) optional(const optional<U&>& rhs)
-        requires(detail::enable_from_other<T, U, U&> && !std::is_convertible_v<U&, T>);
+        requires(detail::enable_from_other<T, U&, U&> && !std::is_convertible_v<U&, T>);
 
     // \ref{optional.dtor}, destructor
     constexpr ~optional()
@@ -341,7 +341,7 @@ class optional {
 
     template <class U>
     constexpr optional& operator=(const optional<U&>& rhs)
-        requires(detail::enable_assign_from_other<T, U, U&>);
+        requires(detail::enable_assign_from_other<T, U&, U&>);
 
     template <class... Args>
     constexpr T& emplace(Args&&... args);
@@ -521,7 +521,7 @@ inline constexpr optional<T>::optional(optional<U>&& rhs)
 template <class T>
 template <class U>
 inline constexpr optional<T>::optional(const optional<U&>& rhs)
-    requires(detail::enable_from_other<T, U, U&> && std::is_convertible_v<U&, T>)
+    requires(detail::enable_from_other<T, U&, U&> && std::is_convertible_v<U&, T>)
 {
     if (rhs.has_value()) {
         construct(*rhs);
@@ -531,7 +531,7 @@ inline constexpr optional<T>::optional(const optional<U&>& rhs)
 template <class T>
 template <class U>
 inline constexpr optional<T>::optional(const optional<U&>& rhs)
-    requires(detail::enable_from_other<T, U, U&> && !std::is_convertible_v<U&, T>)
+    requires(detail::enable_from_other<T, U&, U&> && !std::is_convertible_v<U&, T>)
 {
     if (rhs.has_value()) {
         construct(*rhs);
@@ -646,7 +646,7 @@ inline constexpr optional<T>& optional<T>::operator=(optional<U>&& rhs)
 template <class T>
 template <class U>
 inline constexpr optional<T>& optional<T>::operator=(const optional<U&>& rhs)
-    requires(detail::enable_assign_from_other<T, U, U&>)
+    requires(detail::enable_assign_from_other<T, U&, U&>)
 {
     if (has_value()) {
         if (rhs.has_value()) {

--- a/src/beman/optional26/tests/optional.t.cpp
+++ b/src/beman/optional26/tests/optional.t.cpp
@@ -870,40 +870,92 @@ TEST(OptionalTest, HashTest) {
 }
 
 // Moving an `optional<T&>` should not move the remote value.
-// Check this by deleting the rvalue overloads of some (unrealistic) types.
-TEST(OptionalTest, MoveRef) {
-    struct copyable_but_not_movable {
-        explicit copyable_but_not_movable()                                  = default;
-        copyable_but_not_movable(const copyable_but_not_movable&)            = default;
-        copyable_but_not_movable(copyable_but_not_movable&&)                 = delete;
-        copyable_but_not_movable& operator=(const copyable_but_not_movable&) = default;
-        copyable_but_not_movable& operator=(copyable_but_not_movable&&)      = delete;
-    };
+TEST(OptionalTest, OptionalFromOptionalRef) {
+    using beman::optional26::tests::copyable_from_non_const_lvalue_only;
 
-    copyable_but_not_movable cm;
+    copyable_from_non_const_lvalue_only cm;
 
-    beman::optional26::optional<copyable_but_not_movable&> o1 = cm;
+    beman::optional26::optional<copyable_from_non_const_lvalue_only&> o1 = cm;
     ASSERT_TRUE(o1);
 
-    beman::optional26::optional<copyable_but_not_movable> o2 = std::move(o1);
+    {
+        beman::optional26::optional<copyable_from_non_const_lvalue_only> o2 = o1;
+        ASSERT_TRUE(o2);
+    }
+
+    beman::optional26::optional<copyable_from_non_const_lvalue_only> o2 = std::move(o1);
+    ASSERT_TRUE(o2);
+
+    o2 = o1;
     ASSERT_TRUE(o2);
 
     o2 = std::move(o1);
     ASSERT_TRUE(o2);
 
     o2.reset();
+    o2 = o1;
+    ASSERT_TRUE(o2);
+
+    o2.reset();
+    o2 = std::move(o1);
+    ASSERT_TRUE(o2);
+}
+
+TEST(OptionalTest, OptionalFromOptionalRefExplicit) {
+    using beman::optional26::tests::copyable_from_non_const_lvalue_only;
+    using beman::optional26::tests::explicitly_convertible_from_non_const_lvalue_only;
+
+    explicitly_convertible_from_non_const_lvalue_only ec;
+
+    beman::optional26::optional<explicitly_convertible_from_non_const_lvalue_only&> o3 = ec;
+
+    beman::optional26::optional<copyable_from_non_const_lvalue_only> o4(o3);
+    ASSERT_TRUE(o4);
+    beman::optional26::optional<copyable_from_non_const_lvalue_only> o5(std::move(o3));
+    ASSERT_TRUE(o5);
+}
+
+TEST(OptionalTest, OptionalFromOptionalConstRef) {
+    using beman::optional26::tests::copyable_from_const_lvalue_only;
+
+    copyable_from_const_lvalue_only cm;
+
+    beman::optional26::optional<const copyable_from_const_lvalue_only&> o1 = cm;
+    ASSERT_TRUE(o1);
+
+    {
+        beman::optional26::optional<copyable_from_const_lvalue_only> o2 = o1;
+        ASSERT_TRUE(o2);
+    }
+
+    beman::optional26::optional<copyable_from_const_lvalue_only> o2 = std::move(o1);
+    ASSERT_TRUE(o2);
+
+    o2 = o1;
+    ASSERT_TRUE(o2);
+
     o2 = std::move(o1);
     ASSERT_TRUE(o2);
 
-    struct explicitly_convertible_to_cbnm {
-        explicit operator copyable_but_not_movable() const& { return copyable_but_not_movable{}; }
-        explicit operator copyable_but_not_movable() && = delete;
-    };
+    o2.reset();
+    o2 = o1;
+    ASSERT_TRUE(o2);
 
-    explicitly_convertible_to_cbnm ec;
+    o2.reset();
+    o2 = std::move(o1);
+    ASSERT_TRUE(o2);
+}
 
-    beman::optional26::optional<explicitly_convertible_to_cbnm&> o3 = ec;
+TEST(OptionalTest, OptionalFromOptionalConstRefExplicit) {
+    using beman::optional26::tests::copyable_from_const_lvalue_only;
+    using beman::optional26::tests::explicitly_convertible_from_const_lvalue_only;
 
-    beman::optional26::optional<copyable_but_not_movable> o4(std::move(o3));
+    explicitly_convertible_from_const_lvalue_only ec;
+
+    beman::optional26::optional<const explicitly_convertible_from_const_lvalue_only&> o3 = ec;
+
+    beman::optional26::optional<copyable_from_const_lvalue_only> o4(o3);
     ASSERT_TRUE(o4);
+    beman::optional26::optional<copyable_from_const_lvalue_only> o5(std::move(o3));
+    ASSERT_TRUE(o5);
 }

--- a/src/beman/optional26/tests/test_types.hpp
+++ b/src/beman/optional26/tests/test_types.hpp
@@ -65,6 +65,44 @@ class Point {
     bool operator==(const Point&) const  = default;
 };
 
+struct copyable_from_non_const_lvalue_only {
+    explicit copyable_from_non_const_lvalue_only()                                              = default;
+    copyable_from_non_const_lvalue_only(copyable_from_non_const_lvalue_only&)                   = default;
+    copyable_from_non_const_lvalue_only(const copyable_from_non_const_lvalue_only&)             = delete;
+    copyable_from_non_const_lvalue_only(copyable_from_non_const_lvalue_only&&)                  = delete;
+    copyable_from_non_const_lvalue_only(const copyable_from_non_const_lvalue_only&&)            = delete;
+    copyable_from_non_const_lvalue_only& operator=(copyable_from_non_const_lvalue_only&)        = default;
+    copyable_from_non_const_lvalue_only& operator=(const copyable_from_non_const_lvalue_only&)  = delete;
+    copyable_from_non_const_lvalue_only& operator=(copyable_from_non_const_lvalue_only&&)       = delete;
+    copyable_from_non_const_lvalue_only& operator=(const copyable_from_non_const_lvalue_only&&) = delete;
+};
+
+struct explicitly_convertible_from_non_const_lvalue_only {
+    explicit operator copyable_from_non_const_lvalue_only() & { return copyable_from_non_const_lvalue_only{}; }
+    explicit operator copyable_from_non_const_lvalue_only() const&  = delete;
+    explicit operator copyable_from_non_const_lvalue_only() &&      = delete;
+    explicit operator copyable_from_non_const_lvalue_only() const&& = delete;
+};
+
+struct copyable_from_const_lvalue_only {
+    explicit copyable_from_const_lvalue_only()                                          = default;
+    copyable_from_const_lvalue_only(copyable_from_const_lvalue_only&)                   = delete;
+    copyable_from_const_lvalue_only(const copyable_from_const_lvalue_only&)             = default;
+    copyable_from_const_lvalue_only(copyable_from_const_lvalue_only&&)                  = delete;
+    copyable_from_const_lvalue_only(const copyable_from_const_lvalue_only&&)            = delete;
+    copyable_from_const_lvalue_only& operator=(copyable_from_const_lvalue_only&)        = delete;
+    copyable_from_const_lvalue_only& operator=(const copyable_from_const_lvalue_only&)  = default;
+    copyable_from_const_lvalue_only& operator=(copyable_from_const_lvalue_only&&)       = delete;
+    copyable_from_const_lvalue_only& operator=(const copyable_from_const_lvalue_only&&) = delete;
+};
+
+struct explicitly_convertible_from_const_lvalue_only {
+    explicit operator copyable_from_const_lvalue_only() & = delete;
+    explicit operator copyable_from_const_lvalue_only() const& { return copyable_from_const_lvalue_only{}; }
+    explicit operator copyable_from_const_lvalue_only() &&      = delete;
+    explicit operator copyable_from_const_lvalue_only() const&& = delete;
+};
+
 } // namespace beman::optional26::tests
 
 #endif // BEMAN_OPTIONAL26_TESTS_TEST_TYPES_HPP


### PR DESCRIPTION
Moving `optional<T&>` into `optional<T>` should probably not result in a move of the remote value. Because of reference collapsing, the constraints of the move constructor/assignment operator of `optional<T>` already check for a copy of the remote value, not a move.

This makes the code match the constraints by ~~moving the `move` before the dereference, since for `optional<T&>`, `*std::move(rhs)` always results in a lvalue reference, not a rvalue reference.~~ introducing new constructor/assignment overloads for `optional<T&>`.

edit: fixes #92
edit: updated for new approach