### PR TITLE
Set 'engaged' flag on assignment correctly

### DIFF
--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -520,9 +520,8 @@ inline constexpr optional<T>& optional<T>::operator=(const optional<T>& rhs)
         reset();
     else if (has_value())
         value_ = rhs.value_;
-    else {
+    else
         construct(rhs.value_);
-    }
     return *this;
 }
 
@@ -536,9 +535,8 @@ optional<T>::operator=(optional<T>&& rhs) noexcept(std::is_nothrow_move_construc
         reset();
     else if (has_value())
         value_ = std::move(rhs.value_);
-    else {
+    else
         construct(std::move(rhs.value_));
-    }
     return *this;
 }
 

--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -424,8 +424,7 @@ inline constexpr optional<T>::optional(const optional& rhs)
     requires std::is_copy_constructible_v<T> && (!std::is_trivially_copy_constructible_v<T>)
 {
     if (rhs.has_value()) {
-        std::construct_at(std::addressof(value_), rhs.value_);
-        engaged_ = true;
+        construct(rhs.value_);
     }
 }
 
@@ -434,8 +433,7 @@ inline constexpr optional<T>::optional(optional&& rhs) noexcept(std::is_nothrow_
     requires std::is_move_constructible_v<T> && (!std::is_trivially_move_constructible_v<T>)
 {
     if (rhs.has_value()) {
-        std::construct_at(std::addressof(value_), std::move(rhs.value()));
-        engaged_ = true;
+        construct(std::move(rhs.value_));
     }
 }
 
@@ -466,8 +464,7 @@ inline constexpr optional<T>::optional(const optional<U>& rhs)
     requires detail::enable_from_other<T, U, const U&> && std::is_convertible_v<const U&, T>
 {
     if (rhs.has_value()) {
-        std::construct_at(std::addressof(value_), rhs.value());
-        engaged_ = true;
+        construct(*rhs);
     }
 }
 
@@ -523,8 +520,9 @@ inline constexpr optional<T>& optional<T>::operator=(const optional<T>& rhs)
         reset();
     else if (has_value())
         value_ = rhs.value_;
-    else
-        std::construct_at(std::addressof(value_), rhs.value_);
+    else {
+        construct(rhs.value_);
+    }
     return *this;
 }
 
@@ -538,8 +536,9 @@ optional<T>::operator=(optional<T>&& rhs) noexcept(std::is_nothrow_move_construc
         reset();
     else if (has_value())
         value_ = std::move(rhs.value_);
-    else
-        std::construct_at(std::addressof(value_), std::move(rhs.value_));
+    else {
+        construct(std::move(rhs.value_));
+    }
     return *this;
 }
 

--- a/src/beman/optional26/tests/optional.t.cpp
+++ b/src/beman/optional26/tests/optional.t.cpp
@@ -208,8 +208,38 @@ TEST(OptionalTest, AssignmentValue) {
      */
     beman::optional26::optional<not_trivial_copy_assignable> o5{5};
     beman::optional26::optional<not_trivial_copy_assignable> o6;
+
+    // Copy into empty optional.
     o6 = o5;
-    EXPECT_TRUE(o5->i_ == 5);
+    EXPECT_TRUE(o6);
+    EXPECT_TRUE(o6->i_ == 5);
+
+    // Move into empty optional.
+    o6.reset();
+    o6 = std::move(o5);
+    EXPECT_TRUE(o6);
+    EXPECT_TRUE(o6->i_ == 5);
+
+    // Copy into engaged optional.
+    beman::optional26::optional<not_trivial_copy_assignable> o7{7};
+    o6 = o7;
+    EXPECT_TRUE(o6);
+    EXPECT_TRUE(o6->i_ == 7);
+
+    // Move into engaged optional.
+    beman::optional26::optional<not_trivial_copy_assignable> o8{8};
+    o6 = std::move(o8);
+    EXPECT_TRUE(o6);
+    EXPECT_TRUE(o6->i_ == 8);
+
+    // Copy from empty into engaged optional.
+    o5.reset();
+    o7 = o5;
+    EXPECT_FALSE(o7);
+
+    // Move from empty into engaged optional.
+    o8 = std::move(o5);
+    EXPECT_FALSE(o8);
 }
 
 TEST(OptionalTest, Triviality) {


### PR DESCRIPTION
Also, refactor some other places to make use of the 'construct' helper that handles the flag.

This adds some tests for the non-trivial assignment operators, for all six cases:

- copy/move from engaged to engaged
- copy/move from engaged to empty
- copy/move from empty to engaged