### PR TITLE
Modify constructor constraints to make 'optional<any>' work on libc++

### DIFF
--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -202,11 +202,11 @@ concept enable_forward_value = !std::is_same_v<std::decay_t<U>, optional<T>> &&
 
 template <class T, class U, class Other>
 concept enable_from_other =
-    !std::is_same_v<T, U> && std::is_constructible_v<T, Other> && //
-    !std::is_constructible_v<T, optional<U>&> && !std::is_constructible_v<T, optional<U>&&> &&
-    !std::is_constructible_v<T, const optional<U>&> && !std::is_constructible_v<T, const optional<U>&&> &&
-    !std::is_convertible_v<optional<U>&, T> && !std::is_convertible_v<optional<U>&&, T> &&
-    !std::is_convertible_v<const optional<U>&, T> && !std::is_convertible_v<const optional<U>&&, T>;
+    !std::is_same_v<T, U> && std::is_constructible_v<T, Other> && !std::is_constructible_v<T, optional<U>&> &&
+    !std::is_constructible_v<T, optional<U>&&> && !std::is_constructible_v<T, const optional<U>&> &&
+    !std::is_constructible_v<T, const optional<U>&&> && !std::is_convertible_v<optional<U>&, T> &&
+    !std::is_convertible_v<optional<U>&&, T> && !std::is_convertible_v<const optional<U>&, T> &&
+    !std::is_convertible_v<const optional<U>&&, T>;
 
 template <class T, class U>
 concept enable_assign_forward = !std::is_same_v<optional<T>, std::decay_t<U>> &&

--- a/include/beman/optional26/optional.hpp
+++ b/include/beman/optional26/optional.hpp
@@ -197,16 +197,16 @@ struct hash<optional<T>>;
 
 namespace detail {
 template <class T, class U>
-concept enable_forward_value = std::is_constructible_v<T, U&&> && !std::is_same_v<std::decay_t<U>, in_place_t> &&
-                               !std::is_same_v<optional<T>, std::decay_t<U>>;
+concept enable_forward_value = !std::is_same_v<std::decay_t<U>, optional<T>> &&
+                               !std::is_same_v<std::decay_t<U>, in_place_t> && std::is_constructible_v<T, U&&>;
 
 template <class T, class U, class Other>
 concept enable_from_other =
-    std::is_constructible_v<T, Other> && !std::is_constructible_v<T, optional<U>&> &&
-    !std::is_constructible_v<T, optional<U>&&> && !std::is_constructible_v<T, const optional<U>&> &&
-    !std::is_constructible_v<T, const optional<U>&&> && !std::is_convertible_v<optional<U>&, T> &&
-    !std::is_convertible_v<optional<U>&&, T> && !std::is_convertible_v<const optional<U>&, T> &&
-    !std::is_convertible_v<const optional<U>&&, T>;
+    !std::is_same_v<T, U> && std::is_constructible_v<T, Other> && //
+    !std::is_constructible_v<T, optional<U>&> && !std::is_constructible_v<T, optional<U>&&> &&
+    !std::is_constructible_v<T, const optional<U>&> && !std::is_constructible_v<T, const optional<U>&&> &&
+    !std::is_convertible_v<optional<U>&, T> && !std::is_convertible_v<optional<U>&&, T> &&
+    !std::is_convertible_v<const optional<U>&, T> && !std::is_convertible_v<const optional<U>&&, T>;
 
 template <class T, class U>
 concept enable_assign_forward = !std::is_same_v<optional<T>, std::decay_t<U>> &&

--- a/src/beman/optional26/tests/optional.t.cpp
+++ b/src/beman/optional26/tests/optional.t.cpp
@@ -11,6 +11,7 @@
 #include <ranges>
 #include <tuple>
 #include <algorithm>
+#include <any>
 
 #include <gtest/gtest.h>
 
@@ -867,4 +868,14 @@ TEST(OptionalTest, HashTest) {
         auto h2 = std::hash<int>{}(i);
         EXPECT_EQ(h1, h2);
     }
+}
+
+TEST(OptionalTest, OptionalOfAnyWorks) {
+    beman::optional26::optional<std::any> o1 = 42;
+
+    beman::optional26::optional<std::any> o2 = o1;
+    EXPECT_TRUE(std::any_cast<const int&>(*o2) == 42);
+
+    beman::optional26::optional<std::any> o3 = std::move(o1);
+    EXPECT_TRUE(std::any_cast<const int&>(*o3) == 42);
 }


### PR DESCRIPTION
For `enable_forward_value`, I just reordered the constraints so that the check against `optional` comes first. This fixes a "satisfaction of constraint 'detail::enable_forward_value<T, U>' depends on itself" error on clang.

For `enable_from_other` I introduced a `!std::is_same_v<T, U>` as the first check. This also fixes a "satisfaction of constraint ... depends on itself" error. This check should lead to no change in behavior as in the case where `T` and `U` are the same, `optional<T>`'s copy/move constructors should be used anyway.